### PR TITLE
replaced exec function with pythons __dict__ attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ pyenv/
 
 # Ignore cached directories
 __pycache__
+.mypy_cache
+build/
 
 # Local tests directory
 tests/

--- a/kodijsonrpc/kodijsonrpc.py
+++ b/kodijsonrpc/kodijsonrpc.py
@@ -76,8 +76,7 @@ class KodiJSONClient(object):
     self.url = 'http://{0}:{1}/'.format(host, port)
     self.server = HTTPServer(self.url + 'jsonrpc', headers={'content-type': 'application/json'}, auth=(user, pwd))
     for namespace in KODI_JSON_NAMESPACES:
-      inst = "self.{0} = KodiNamespaceMethodCatcher(self.server, '{0}')".format(namespace)
-      exec(inst)
+      self.__dict__[namespace] = KodiNamespaceMethodCatcher(self.server, namespace)
 
 #################################################
 #

--- a/kodijsonrpc/kodijsonrpc.py
+++ b/kodijsonrpc/kodijsonrpc.py
@@ -1,93 +1,73 @@
 #!/usr/bin/env python3
-
-'''
-kodijsonrpc.py
+"""kodijsonrpc.py
 
 Set up Kodi specific JSON RPC client.
 
 All Kodi JSON methods can be called as functions
 to the KodiJSONClient instance.
-
-'''
+"""
 
 from jsonrpcclient.http_server import HTTPServer
 
-KODI_JSON_NAMESPACES = ["VideoLibrary",
-                        "Settings",
-                        "Favourites",
-                        "AudioLibrary",
-                        "Application",
-                        "Player",
-                        "Input",
-                        "System",
-                        "Playlist",
-                        "Addons",
-                        "AudioLibrary",
-                        "Files",
-                        "GUI" ,
-                        "JSONRPC",
-                        "PVR",
-                        "xbmc"]
+KODI_JSON_NAMESPACES = [
+    "VideoLibrary", "Settings", "Favourites", "AudioLibrary", "Application",
+    "Player", "Input", "System", "Playlist", "Addons", "AudioLibrary", "Files",
+    "GUI", "JSONRPC", "PVR", "xbmc"
+]
 
-#################################################
-#
-# KodiNamespaceMethodCatcher
-#
-# This provides a __getattr__ method which
-# catches all method calls and makes the
-# corresponding server requests.
-#
-#################################################
+
 class KodiNamespaceMethodCatcher(object):
-  #################################################
-  # __init__
-  #################################################
-  def __init__(self, server, namespace):
-    self.server = server
-    self.namespace = namespace
+    """KodiNamespaceMethodCatcher
 
-  #################################################
-  # __getattr__ : catch all function calls
-  #################################################
-  def __getattr__(self, function):
-    def func(*args, **kwargs):
-      return self.server.request("{0}.{1}".format(self.namespace, function), *args, **kwargs)
-    return func
+    This provides a __getattr__ method which
+    catches all method calls and makes the
+    corresponding server requests.
+    """
 
-#################################################
-#
-# KodiJSONClient
-#
-# Insantiate KodiNamespaceMethodCatcher classes
-# for all Kodi JSON namespaces. This allows any
-# of the Kodi JSON methods to be called as methods
-# of the KodiJSONClient
-#
-# e.g <KodiJSONClient object>.JSONRPC.Ping()
-# would result in a ping request sent to the
-# configured kodi server.
-#
-#################################################
+    def __init__(self, server, namespace):
+        """__init__"""
+        self.server = server
+        self.namespace = namespace
+
+    def __getattr__(self, function):
+        """__getattr__ : catch all function calls"""
+        def func(*args, **kwargs):
+            return self.server.request(
+                "{0}.{1}".format(self.namespace, function), *args, **kwargs)
+
+        return func
+
+
 class KodiJSONClient(object):
-  #################################################
-  # __init__
-  #################################################
-  def __init__(self, host, port, user, pwd):
-    self.url = 'http://{0}:{1}/'.format(host, port)
-    self.server = HTTPServer(self.url + 'jsonrpc', headers={'content-type': 'application/json'}, auth=(user, pwd))
-    for namespace in KODI_JSON_NAMESPACES:
-      self.__dict__[namespace] = KodiNamespaceMethodCatcher(self.server, namespace)
+    """KodiJSONClient
 
-#################################################
-#
-# EnableJSONLogging
-#
-# Enable logging on jsconrpcclient module
-#
-#################################################
-def EnableJSONLogging():
-  import logging
-  logging.getLogger('jsonrpcclient').setLevel(logging.INFO)
-  logging.basicConfig()
+    Insantiate KodiNamespaceMethodCatcher classes
+    for all Kodi JSON namespaces. This allows any
+    of the Kodi JSON methods to be called as methods
+    of the KodiJSONClient
+
+    e.g <KodiJSONClient object>.JSONRPC.Ping()
+    would result in a ping request sent to the
+    configured kodi server.
+    """
+
+    def __init__(self, host, port, user, pwd):
+        """__init__"""
+        self.url = 'http://{0}:{1}/'.format(host, port)
+        self.server = HTTPServer(
+            self.url + 'jsonrpc',
+            headers={'content-type': 'application/json'},
+            auth=(user, pwd))
+        for namespace in KODI_JSON_NAMESPACES:
+            self.__dict__[namespace] = KodiNamespaceMethodCatcher(
+                self.server, namespace)
 
 
+def enable_json_logging():
+    """EnableJSONLogging
+
+    Enable logging on jsconrpcclient module
+    """
+    import logging
+    logging.getLogger('jsonrpcclient').setLevel(logging.INFO)
+    logging.basicConfig()


### PR DESCRIPTION
there is no need for dynamic execution of the code with exec. also adding attributes with exec shouldn't be used if not necessary. this should work like before and is more the way to go.

i have tested with the functions `server.JSONRPC.Ping()` and `server.Player.Open(item={"file": url})`.